### PR TITLE
更新兼容空间的文档导出

### DIFF
--- a/src/baseurl.js
+++ b/src/baseurl.js
@@ -1,0 +1,11 @@
+let url = ""
+if (!process.env.SPACE_URL) {
+    url = "https://www.yuque.com"
+} else {
+    // 团队空间的URL，结尾不带 '/'
+    // 样例  https://xxxx.yuque.com
+    url = process.env.SPACE_URL
+}
+
+export const baseurl = url
+

--- a/src/export.js
+++ b/src/export.js
@@ -1,185 +1,127 @@
 import fs from 'fs';
-import { Readable } from 'stream';
+import path from 'path';
 import { type } from './const.js';
-import jsonstream from 'jsonstream';
 import { baseurl } from './baseurl.js';
 
-class BookPage {
-    constructor(id, uuid, name, url, type, parent_uuid, child_uuid, sibling_uuid) {
-        this.id = id;
-        this.uuid = uuid;
-        this.name = name;
-        this.url = url;
-        this.type = type;
-        this.parent_uuid = parent_uuid;
-        this.child_uuid = child_uuid;
-        this.sibling_uuid = sibling_uuid;
-    }
-}
-
-
-class Book {
-    root
-    user_url
-    constructor(id, name, slug) {
-      this.id = id;
-      this.name = name;
-      this.slug = slug
-    }
-}
-
-export async function getAllBooks(page) {
-    const books = [];
-    const response = await page.goto(baseurl + '/api/mine/common_used', { waitUntil: 'networkidle0' });
-    const data = await response.text();
-    const parser = jsonstream.parse('data.*');
-    
-    const bookData = await new Promise((resolve) => {
-        const parsedBooks = [];
-        parser.on('data', (object) => {
-            parsedBooks.push(object);
-        });
-        parser.on('end', () => {
-            resolve(parsedBooks);
-        });
-        parser.end(data);
-    });
-
-    for (const object of bookData) {
-        if (object.length == 0 ){
-            continue
-        }
-        for (let i = 0; i < object.length; i++) {
-            if (object[i].type == 'Book') {
-                const book = new Book(object[i].target.id, delNonStdChars(object[i].target.name), object[i].target.slug);
-                book.root = await getBookDetail(page, book);
-                book.user_url = object[i].target.user.login
-                books.push(book);
-            }
-        }
+export async function exportMarkDownFiles(page, books) {
+    const folderPath = process.env.EXPORT_PATH;
+    console.log("download folderPath: " + folderPath)
+    if (!fs.existsSync(folderPath)) {
+        console.error(`export path:${folderPath} is not exist`)
+        process.exit(1)
     }
 
-    console.log(`Books count is: ${books.length}`);
-    return books;
-}
-
-// async function getBookDetail(page, book) {
-//     const url = 'https://www.yuque.com/api/catalog_nodes?book_id=' + book.id;
-//     const response = await page.goto(url, { waitUntil: 'networkidle0' });
-//     const data = await response.text();
-//     const parser = jsonstream.parse('data.*');
-
-//     const bookData = await new Promise((resolve) => {
-//         var uuidMap = new Map();
-//         let firstSubItem;
-
-//         parser.on('data', (object) => {
-//             if (firstSubItem === undefined && object.parent_uuid === "") {
-//                 firstSubItem = object;
-//             }
-//             const bookPage = new BookPage(object.id, object.uuid, delNonStdChars(object.title),
-//                 object.url, object.type, object.parent_uuid, object.child_uuid, object.sibling_uuid);
-//             uuidMap.set(object.uuid, bookPage);
-//         });
-
-//         parser.on('end', () => {
-//             resolve({ firstSubItem, uuidMap });
-//         });
-//         parser.end(data);
-//     });
-
-//     const { firstSubItem, uuidMap } = bookData;
-//     const root = { name: delNonStdChars(book.name), type: type.Book, object: book };
-//     if (firstSubItem) {
-//         buildDirectoryTree(uuidMap, firstSubItem.uuid, root);
-//         printDirectoryTree(root);
-//     }
-
-//     return root;
-// }
-
-async function getBookDetail(page, book) {
-    return new Promise(async (resolve, reject) => {
-        var uuidMap = new Map();
-        let fristSubItem;
-        var url = baseurl + '/api/catalog_nodes?book_id=' + book.id;
-        var response = await page.goto(url, { waitUntil: 'networkidle0' });
-        var data = await response.text();
-        var parser = jsonstream.parse('data.*');
-
-        parser.on('data', (object) => {
-            if (fristSubItem === undefined && object.parent_uuid === "") {
-                fristSubItem = object;
-            }
-            const bookPage = new BookPage(object.id, object.uuid, delNonStdChars(object.title),
-                object.url, object.type, object.parent_uuid, object.child_uuid, object.sibling_uuid);
-            uuidMap.set(object.uuid, bookPage);
-        });
-
-        parser.on('end', () => {
-            // 创建一个目录树的根节点
-            const root = { name: delNonStdChars(book.name), type: type.Book, object: book };
-            if (fristSubItem) {
-                buildDirectoryTree(uuidMap, fristSubItem.uuid, root);
-                printDirectoryTree(root);
-            } 
-            resolve(root); 
-        
-        });
-
-        parser.end(data);
-    });
-}
-  
-
-
-function buildDirectoryTree(uuidMap, uuid, node) {
-    const item = uuidMap.get(uuid);
-    if (!item) return;
-
-    // 在当前节点下创建子节点
-    const childNode = { name: item.name, type: item.type, object: item };
-    if (item.child_uuid) {
-        if (item.type === type.Document) {
-            childNode.type = type.TitleDoc;
-        }
-        buildDirectoryTree(uuidMap, item.child_uuid, childNode);
-    }
-
-    if (item.sibling_uuid) {
-        buildDirectoryTree(uuidMap, item.sibling_uuid, node);
-    }
-
-    // 将子节点添加到当前节点
-    if (!node.children) {
-        node.children = [];
-    }
-    node.children.push(childNode);
-}
-
-
-// 打印目录树函数
-export function printDirectoryTree(node, indent = 0) {
-    const indentation = '  '.repeat(indent);
-    if (node.type === type.Book) {
+    // console.log(books)
+    for ( let i = 0; i < books.length; i++ ) {
+        await exportMarkDownFileTree(page, folderPath, books[i], books[i].root)
         console.log();
-        console.log(indentation + node.name + "/" + node.object.slug);
-    } else {
-        console.log(indentation + node.name + "/" + node.object.url);
+    }
+
+    console.log(`=====> Export successfully! Have a good day!`);
+    console.log();
+}
+
+
+async function exportMarkDownFileTree(page, folderPath, book, node) {
+    switch (node.type) {
+        case type.Book: 
+            folderPath = path.join(folderPath, book.name);
+            if (!fs.existsSync(folderPath)) {
+                fs.mkdirSync(folderPath)
+            }
+            break;
+        case type.Title: 
+            folderPath = path.join(folderPath, node.name);
+            if (!fs.existsSync(folderPath)) {
+                fs.mkdirSync(folderPath)
+            }
+            break;
+        case type.TitleDoc: 
+            folderPath = path.join(folderPath, node.name);
+            if (!fs.existsSync(folderPath)) {
+                fs.mkdirSync(folderPath)
+            }
+        case type.Document: 
+            const client = await page.target().createCDPSession()
+            await client.send('Page.setDownloadBehavior', {
+                behavior: 'allow',
+                downloadPath: folderPath,
+            })
+            await downloadMardown(page, folderPath, book.name, node.name.replace(/\//g, '_'),
+                book.user_url + "/" + book.slug + "/" + node.object.url)
+            break;
     }
 
     if (node.children) {
-        node.children.forEach(childNode => {
-            printDirectoryTree(childNode, indent + 1);
-        });
+        for (const childNode of node.children) {
+            await exportMarkDownFileTree(page, folderPath, book, childNode);
+        }
     }
 }
 
-function delNonStdChars(str) {
-    return str.replace(/\//g, "_").
-        replace(/"/g, '_').
-        replace(/:/g, '_').
-        replace(/\?/g, '_').
-        replace(/[\\/:\*\?"<>\|]/g, '').
-        trim();
+
+// browserpage, bookName, url
+async function downloadMardown(page, rootPath, book, mdname, docUrl) {
+    const url = baseurl + "/" + docUrl + '/markdown?attachment=true&latexcode=false&anchor=false&linebreak=false';
+    // console.log(book + "/" + mdname + "'s download URL is: " + url)
+    // console.log(rootPath)
+
+    await downloadFile(page, rootPath, book, mdname, url)
+    // await page.waitForTimeout(1000);
+}
+
+async function downloadFile(page, rootPath, book, mdname, url, maxRetries = 3) {
+    var retries = 0;
+
+    async function downloadWithRetries() {
+        try {
+            await goto(page, url);
+            console.log(`Waiting download document to ${rootPath}\\${mdname}`);
+            const fileNameWithExt = await waitForDownload(rootPath, book, mdname);
+            const fileName = path.basename(fileNameWithExt, path.extname(fileNameWithExt));
+            console.log("Download document " + book + "/" + fileName + " finished");
+            console.log();
+        } catch (error) {
+            console.log(error);
+            if (retries < maxRetries) {
+                console.log(`Retrying download... (attempt ${retries + 1})`);
+                retries++;
+                await downloadWithRetries();
+            } else {
+                console.log(`Download error after ${maxRetries} retries: ${error}`);
+            }
+        }
+    }
+
+    await downloadWithRetries();
+}
+
+async function goto(page, link) {
+    page.evaluate((link) => {
+        location.href = link;
+    }, link);
+}
+  
+async function waitForDownload(rootPath, book, mdname, started = false) {
+    const timeout = 10000; // 10s timeout
+    return new Promise((resolve, reject) => {
+        // console.log(`======> watch ${rootPath} ${mdname}.md`)
+        const watcher = fs.watch(rootPath, (eventType, filename) => {
+            // console.log(`watch ${rootPath} ${eventType} ${filename}, want ${mdname}.md`)
+            if (eventType === 'rename' && filename === `${mdname}.md.crdownload` && !started) {
+                console.log("Downloading document " + book + "/" + mdname)
+                started = true
+            }
+
+            if (eventType === 'rename' && filename === `${mdname}.md` && started) {
+                watcher.close();
+                resolve(filename);
+            }
+        });
+
+        setTimeout(() => {
+            watcher.close();
+            reject(new Error('Download timed out'));
+        }, timeout);
+    });
 }

--- a/src/export.js
+++ b/src/export.js
@@ -1,127 +1,185 @@
 import fs from 'fs';
-import path from 'path';
+import { Readable } from 'stream';
 import { type } from './const.js';
+import jsonstream from 'jsonstream';
 import { baseurl } from './baseurl.js';
 
-export async function exportMarkDownFiles(page, books) {
-    const folderPath = process.env.EXPORT_PATH;
-    console.log("download folderPath: " + folderPath)
-    if (!fs.existsSync(folderPath)) {
-        console.error(`export path:${folderPath} is not exist`)
-        process.exit(1)
+class BookPage {
+    constructor(id, uuid, name, url, type, parent_uuid, child_uuid, sibling_uuid) {
+        this.id = id;
+        this.uuid = uuid;
+        this.name = name;
+        this.url = url;
+        this.type = type;
+        this.parent_uuid = parent_uuid;
+        this.child_uuid = child_uuid;
+        this.sibling_uuid = sibling_uuid;
     }
-
-    // console.log(books)
-    for ( let i = 0; i < books.length; i++ ) {
-        await exportMarkDownFileTree(page, folderPath, books[i], books[i].root)
-        console.log();
-    }
-
-    console.log(`=====> Export successfully! Have a good day!`);
-    console.log();
 }
 
 
-async function exportMarkDownFileTree(page, folderPath, book, node) {
-    switch (node.type) {
-        case type.Book: 
-            folderPath = path.join(folderPath, book.name);
-            if (!fs.existsSync(folderPath)) {
-                fs.mkdirSync(folderPath)
+class Book {
+    root
+    user_url
+    constructor(id, name, slug) {
+      this.id = id;
+      this.name = name;
+      this.slug = slug
+    }
+}
+
+export async function getAllBooks(page) {
+    const books = [];
+    const response = await page.goto(baseurl + '/api/mine/common_used', { waitUntil: 'networkidle0' });
+    const data = await response.text();
+    const parser = jsonstream.parse('data.*');
+    
+    const bookData = await new Promise((resolve) => {
+        const parsedBooks = [];
+        parser.on('data', (object) => {
+            parsedBooks.push(object);
+        });
+        parser.on('end', () => {
+            resolve(parsedBooks);
+        });
+        parser.end(data);
+    });
+
+    for (const object of bookData) {
+        if (object.length == 0 ){
+            continue
+        }
+        for (let i = 0; i < object.length; i++) {
+            if (object[i].type == 'Book') {
+                const book = new Book(object[i].target.id, delNonStdChars(object[i].target.name), object[i].target.slug);
+                book.root = await getBookDetail(page, book);
+                book.user_url = object[i].target.user.login
+                books.push(book);
             }
-            break;
-        case type.Title: 
-            folderPath = path.join(folderPath, node.name);
-            if (!fs.existsSync(folderPath)) {
-                fs.mkdirSync(folderPath)
+        }
+    }
+
+    console.log(`Books count is: ${books.length}`);
+    return books;
+}
+
+// async function getBookDetail(page, book) {
+//     const url = 'https://www.yuque.com/api/catalog_nodes?book_id=' + book.id;
+//     const response = await page.goto(url, { waitUntil: 'networkidle0' });
+//     const data = await response.text();
+//     const parser = jsonstream.parse('data.*');
+
+//     const bookData = await new Promise((resolve) => {
+//         var uuidMap = new Map();
+//         let firstSubItem;
+
+//         parser.on('data', (object) => {
+//             if (firstSubItem === undefined && object.parent_uuid === "") {
+//                 firstSubItem = object;
+//             }
+//             const bookPage = new BookPage(object.id, object.uuid, delNonStdChars(object.title),
+//                 object.url, object.type, object.parent_uuid, object.child_uuid, object.sibling_uuid);
+//             uuidMap.set(object.uuid, bookPage);
+//         });
+
+//         parser.on('end', () => {
+//             resolve({ firstSubItem, uuidMap });
+//         });
+//         parser.end(data);
+//     });
+
+//     const { firstSubItem, uuidMap } = bookData;
+//     const root = { name: delNonStdChars(book.name), type: type.Book, object: book };
+//     if (firstSubItem) {
+//         buildDirectoryTree(uuidMap, firstSubItem.uuid, root);
+//         printDirectoryTree(root);
+//     }
+
+//     return root;
+// }
+
+async function getBookDetail(page, book) {
+    return new Promise(async (resolve, reject) => {
+        var uuidMap = new Map();
+        let fristSubItem;
+        var url = baseurl + '/api/catalog_nodes?book_id=' + book.id;
+        var response = await page.goto(url, { waitUntil: 'networkidle0' });
+        var data = await response.text();
+        var parser = jsonstream.parse('data.*');
+
+        parser.on('data', (object) => {
+            if (fristSubItem === undefined && object.parent_uuid === "") {
+                fristSubItem = object;
             }
-            break;
-        case type.TitleDoc: 
-            folderPath = path.join(folderPath, node.name);
-            if (!fs.existsSync(folderPath)) {
-                fs.mkdirSync(folderPath)
-            }
-        case type.Document: 
-            const client = await page.target().createCDPSession()
-            await client.send('Page.setDownloadBehavior', {
-                behavior: 'allow',
-                downloadPath: folderPath,
-            })
-            await downloadMardown(page, folderPath, book.name, node.name.replace(/\//g, '_'),
-                book.user_url + "/" + book.slug + "/" + node.object.url)
-            break;
+            const bookPage = new BookPage(object.id, object.uuid, delNonStdChars(object.title),
+                object.url, object.type, object.parent_uuid, object.child_uuid, object.sibling_uuid);
+            uuidMap.set(object.uuid, bookPage);
+        });
+
+        parser.on('end', () => {
+            // 创建一个目录树的根节点
+            const root = { name: delNonStdChars(book.name), type: type.Book, object: book };
+            if (fristSubItem) {
+                buildDirectoryTree(uuidMap, fristSubItem.uuid, root);
+                printDirectoryTree(root);
+            } 
+            resolve(root); 
+        
+        });
+
+        parser.end(data);
+    });
+}
+  
+
+
+function buildDirectoryTree(uuidMap, uuid, node) {
+    const item = uuidMap.get(uuid);
+    if (!item) return;
+
+    // 在当前节点下创建子节点
+    const childNode = { name: item.name, type: item.type, object: item };
+    if (item.child_uuid) {
+        if (item.type === type.Document) {
+            childNode.type = type.TitleDoc;
+        }
+        buildDirectoryTree(uuidMap, item.child_uuid, childNode);
+    }
+
+    if (item.sibling_uuid) {
+        buildDirectoryTree(uuidMap, item.sibling_uuid, node);
+    }
+
+    // 将子节点添加到当前节点
+    if (!node.children) {
+        node.children = [];
+    }
+    node.children.push(childNode);
+}
+
+
+// 打印目录树函数
+export function printDirectoryTree(node, indent = 0) {
+    const indentation = '  '.repeat(indent);
+    if (node.type === type.Book) {
+        console.log();
+        console.log(indentation + node.name + "/" + node.object.slug);
+    } else {
+        console.log(indentation + node.name + "/" + node.object.url);
     }
 
     if (node.children) {
-        for (const childNode of node.children) {
-            await exportMarkDownFileTree(page, folderPath, book, childNode);
-        }
-    }
-}
-
-
-// browserpage, bookName, url
-async function downloadMardown(page, rootPath, book, mdname, docUrl) {
-    const url = baseurl + "/" + docUrl + '/markdown?attachment=true&latexcode=false&anchor=false&linebreak=false';
-    // console.log(book + "/" + mdname + "'s download URL is: " + url)
-    // console.log(rootPath)
-
-    await downloadFile(page, rootPath, book, mdname, url)
-    // await page.waitForTimeout(1000);
-}
-
-async function downloadFile(page, rootPath, book, mdname, url, maxRetries = 3) {
-    var retries = 0;
-
-    async function downloadWithRetries() {
-        try {
-            await goto(page, url);
-            console.log(`Waiting download document to ${rootPath}\\${mdname}`);
-            const fileNameWithExt = await waitForDownload(rootPath, book, mdname);
-            const fileName = path.basename(fileNameWithExt, path.extname(fileNameWithExt));
-            console.log("Download document " + book + "/" + fileName + " finished");
-            console.log();
-        } catch (error) {
-            console.log(error);
-            if (retries < maxRetries) {
-                console.log(`Retrying download... (attempt ${retries + 1})`);
-                retries++;
-                await downloadWithRetries();
-            } else {
-                console.log(`Download error after ${maxRetries} retries: ${error}`);
-            }
-        }
-    }
-
-    await downloadWithRetries();
-}
-
-async function goto(page, link) {
-    page.evaluate((link) => {
-        location.href = link;
-    }, link);
-}
-  
-async function waitForDownload(rootPath, book, mdname, started = false) {
-    const timeout = 10000; // 10s timeout
-    return new Promise((resolve, reject) => {
-        // console.log(`======> watch ${rootPath} ${mdname}.md`)
-        const watcher = fs.watch(rootPath, (eventType, filename) => {
-            // console.log(`watch ${rootPath} ${eventType} ${filename}, want ${mdname}.md`)
-            if (eventType === 'rename' && filename === `${mdname}.md.crdownload` && !started) {
-                console.log("Downloading document " + book + "/" + mdname)
-                started = true
-            }
-
-            if (eventType === 'rename' && filename === `${mdname}.md` && started) {
-                watcher.close();
-                resolve(filename);
-            }
+        node.children.forEach(childNode => {
+            printDirectoryTree(childNode, indent + 1);
         });
+    }
+}
 
-        setTimeout(() => {
-            watcher.close();
-            reject(new Error('Download timed out'));
-        }, timeout);
-    });
+function delNonStdChars(str) {
+    return str.replace(/\//g, "_").
+        replace(/"/g, '_').
+        replace(/:/g, '_').
+        replace(/\?/g, '_').
+        replace(/[\\/:\*\?"<>\|]/g, '').
+        trim();
 }

--- a/src/export.js
+++ b/src/export.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { type } from './const.js';
+import { baseurl } from './baseurl.js';
 
 export async function exportMarkDownFiles(page, books) {
     const folderPath = process.env.EXPORT_PATH;
@@ -61,7 +62,7 @@ async function exportMarkDownFileTree(page, folderPath, book, node) {
 
 // browserpage, bookName, url
 async function downloadMardown(page, rootPath, book, mdname, docUrl) {
-    const url = 'https://www.yuque.com/' + docUrl + '/markdown?attachment=true&latexcode=false&anchor=false&linebreak=false';
+    const url = baseurl + "/" + docUrl + '/markdown?attachment=true&latexcode=false&anchor=false&linebreak=false';
     // console.log(book + "/" + mdname + "'s download URL is: " + url)
     // console.log(rootPath)
 

--- a/src/login.js
+++ b/src/login.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { baseurl } from './baseurl.js';
 
 export async function autoLogin(page) {
     const cookieFile = './cookies.json';
@@ -12,7 +13,7 @@ export async function autoLogin(page) {
     if (cookies.length > 0) {
       console.log("Login use cookies...")
       await page.setCookie(...cookies);
-      await page.goto('https://www.yuque.com/dashboard');
+      await page.goto(baseurl + '/dashboard');
     } else {
       console.log("Login use user + password...")
       if (!process.env.USER) {
@@ -25,7 +26,7 @@ export async function autoLogin(page) {
         process.exit(1);
       }
   
-      await page.goto('https://www.yuque.com/login');
+      await page.goto(baseurl + '/login');
       // Switch to password login
       await page.click('.switch-btn');
   


### PR DESCRIPTION
新增 baseurl.js 用于统一请求的url，并可接收 空间url 的环境变量；
更新其他几个 js 中硬编码的 `https://www.yuque.com`；
变更 toc.js 中 `/api/mine/book_stacks` 接口为 `/api/mine/common_used` 以兼容空间文档的下载，并修改对应获取 Book 的代码；
本地测试 个人文档和空间文档 OK。
（第一次写nodejs，不规范的可以帮忙修改下）